### PR TITLE
Update for upcoming IJ 2019.2

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -133,5 +133,5 @@
   </actions>
 
   <depends>org.jetbrains.plugins.gradle</depends>
-
+  <depends>org.jetbrains.idea.maven</depends>
 </idea-plugin>


### PR DESCRIPTION
Add missing dependency. Before 2019.2 it was satisfied due to Gradle plugin having optional dependency on Maven plugin, which is not true any longer