### PR TITLE
Set in MOE 2.0 GraalVM as jdk instead of moe

### DIFF
--- a/src/main/kotlin/org/moe/idea/model/impl/MOESdkPropertiesImpl.kt
+++ b/src/main/kotlin/org/moe/idea/model/impl/MOESdkPropertiesImpl.kt
@@ -1,18 +1,26 @@
 package org.moe.idea.model.impl
 
+import org.gradle.tooling.model.UnsupportedMethodException
 import org.moe.gradle.model.MOESdkProperties
 import java.io.Serializable
+import java.lang.UnsupportedOperationException
 
 data class MOESdkPropertiesImpl(
     override val home: String,
     override val coreJar: String,
     override val platformJar: String?,
-    override val junitJar: String
+    override val junitJar: String,
+    override val graalHome: String?
 ) : MOESdkProperties, Serializable {
     constructor(input: MOESdkProperties) : this(
         home = input.home,
         coreJar = input.coreJar,
         platformJar = input.platformJar,
-        junitJar = input.junitJar
+        junitJar = input.junitJar,
+        graalHome = try {
+            input.graalHome
+        } catch (_: UnsupportedMethodException) {
+            null
+        }
     )
 }


### PR DESCRIPTION
This is currently only enabled for moe 2.0. I tested it a bit and it seems to work fine. Theoretical if I didn't missed anything we could also remove the whole sdk creation etc. also for MOE 1.9 and set directly the jdk which would be otherwise just wrapped. 
(I also fixed some NPE bugs.)
Relatded prs: https://github.com/multi-os-engine/moe-plugin-gradle/pull/10 https://github.com/multi-os-engine/moe-tools-common/pull/2