### PR TITLE
Fix for crash when opening a nbc file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ def PLUGIN_NAME = 'moe_intellij_plugin'
 //}
 
 intellij {
+    // to test with Android Studio, use:
+    // version = 'AI-231.9392.1.2311.11076708'
     version = 'IC-2022.2'
     plugins = ['com.intellij.gradle', 'com.intellij.java']
     pluginName = PLUGIN_NAME

--- a/src/main/java/org/moe/idea/editors/BindingEditor.java
+++ b/src/main/java/org/moe/idea/editors/BindingEditor.java
@@ -24,7 +24,7 @@ import com.intellij.openapi.fileEditor.FileEditorState;
 import com.intellij.openapi.fileEditor.FileEditorStateLevel;
 import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.UserDataHolderBase;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileListener;
 import org.jetbrains.annotations.NotNull;
@@ -34,7 +34,7 @@ import org.moe.idea.ui.BindingEditorForm;
 import javax.swing.*;
 import java.beans.PropertyChangeListener;
 
-public class BindingEditor implements VirtualFileListener, FileEditor {
+public class BindingEditor extends UserDataHolderBase implements VirtualFileListener, FileEditor {
 
     @NotNull
     private final VirtualFile myFile;
@@ -121,17 +121,6 @@ public class BindingEditor implements VirtualFileListener, FileEditor {
     @Override
     public void dispose() {
         TextEditorProvider.getInstance().disposeEditor(this);
-    }
-
-    @Nullable
-    @Override
-    public <T> T getUserData(@NotNull Key<T> key) {
-        return null;
-    }
-
-    @Override
-    public <T> void putUserData(@NotNull Key<T> key, @Nullable T t) {
-
     }
 
     @Override

--- a/src/main/java/org/moe/idea/ui/BindingEditorListForm.form
+++ b/src/main/java/org/moe/idea/ui/BindingEditorListForm.form
@@ -77,35 +77,30 @@
           <component id="7e8f7" class="javax.swing.JButton" binding="addButton">
             <constraints/>
             <properties>
-              <icon value="general/add.png"/>
               <toolTipText value="Add"/>
             </properties>
           </component>
           <component id="dda18" class="javax.swing.JButton" binding="removeButton">
             <constraints/>
             <properties>
-              <icon value="general/remove.png"/>
               <toolTipText value="Remove"/>
             </properties>
           </component>
           <component id="14ce" class="javax.swing.JButton" binding="upButton" default-binding="true">
             <constraints/>
             <properties>
-              <icon value="actions/moveUp.png"/>
               <toolTipText value="Move Up"/>
             </properties>
           </component>
           <component id="6632e" class="javax.swing.JButton" binding="downButton" default-binding="true">
             <constraints/>
             <properties>
-              <icon value="actions/moveDown.png"/>
               <toolTipText value="Move Down"/>
             </properties>
           </component>
           <component id="c6a16" class="javax.swing.JButton" binding="actionsButton">
             <constraints/>
             <properties>
-              <icon value="general/gearPlain.png"/>
               <text value=""/>
               <toolTipText value="Actions"/>
             </properties>

--- a/src/main/java/org/moe/idea/ui/BindingEditorListForm.java
+++ b/src/main/java/org/moe/idea/ui/BindingEditorListForm.java
@@ -16,6 +16,7 @@ limitations under the License.
 
 package org.moe.idea.ui;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.DocumentAdapter;
@@ -60,6 +61,12 @@ public class BindingEditorListForm extends JPanel {
     private boolean inited = false;
 
     public BindingEditorListForm() {
+        addButton.setIcon(AllIcons.General.Add);
+        removeButton.setIcon(AllIcons.General.Remove);
+        upButton.setIcon(AllIcons.Actions.MoveUp);
+        downButton.setIcon(AllIcons.Actions.MoveDown);
+        actionsButton.setIcon(AllIcons.General.GearPlain);
+
         this.bindingList = new ArrayList<AbstractBinding>();
         this.listModel = new DefaultListModel();
         bindingsList.setModel(listModel);

--- a/src/main/java/org/moe/idea/ui/LinkedFrameworksForm.form
+++ b/src/main/java/org/moe/idea/ui/LinkedFrameworksForm.form
@@ -13,7 +13,6 @@
           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <icon value="general/add.png"/>
           <toolTipText value="Add"/>
         </properties>
       </component>
@@ -22,7 +21,6 @@
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <icon value="general/remove.png"/>
           <toolTipText value="Remove"/>
         </properties>
       </component>

--- a/src/main/java/org/moe/idea/ui/LinkedFrameworksForm.java
+++ b/src/main/java/org/moe/idea/ui/LinkedFrameworksForm.java
@@ -16,6 +16,7 @@ limitations under the License.
 
 package org.moe.idea.ui;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.ui.DialogWrapper;
 import org.moe.editors.Framework;
 import org.moe.editors.XcodeEditorManager;
@@ -37,6 +38,8 @@ public class LinkedFrameworksForm extends JPanel {
 
     public LinkedFrameworksForm() {
         super();
+        addButton.setIcon(AllIcons.General.Add);
+        removeButton.setIcon(AllIcons.General.Remove);
         this.listModel = new DefaultListModel();
         frameworkList.setModel(listModel);
 

--- a/src/main/java/org/moe/idea/ui/SearchPathForm.form
+++ b/src/main/java/org/moe/idea/ui/SearchPathForm.form
@@ -36,7 +36,6 @@
           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <icon value="general/add.png"/>
           <toolTipText value="Add"/>
         </properties>
       </component>
@@ -45,7 +44,6 @@
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <icon value="general/remove.png"/>
           <toolTipText value="Remove"/>
         </properties>
       </component>

--- a/src/main/java/org/moe/idea/ui/SearchPathForm.java
+++ b/src/main/java/org/moe/idea/ui/SearchPathForm.java
@@ -16,6 +16,7 @@ limitations under the License.
 
 package org.moe.idea.ui;
 
+import com.intellij.icons.AllIcons;
 import org.moe.idea.utils.ModuleUtils;
 
 import javax.swing.*;
@@ -35,6 +36,8 @@ public class SearchPathForm extends JPanel {
     private HeaderBindingEditorForm bindingEditorForm;
 
     public SearchPathForm() {
+        addButton.setIcon(AllIcons.General.Add);
+        removeButton.setIcon(AllIcons.General.Remove);
 
         this.listModel = new DefaultListModel();
         pathList.setModel(listModel);


### PR DESCRIPTION
the editor was marked as being able to hold user data but didnt actually hold it
the intellij notification system wanted to use the user data but it was failing

Android Studio seems to have switched to using SVG for Icons, so we cant reference png files directly